### PR TITLE
[NOT TO MERGE] fix routers prefix

### DIFF
--- a/app/controllers/GreeterRouter.scala
+++ b/app/controllers/GreeterRouter.scala
@@ -6,7 +6,7 @@ import io.grpc.examples.helloworld.{GreeterService, GreeterServiceHandler}
 import javax.inject._
 import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler
-import play.api.routing.Router
+import play.api.routing.{Router, SimpleRouter}
 import play.api.routing.Router.Routes
 
 import scala.concurrent.Future
@@ -19,7 +19,7 @@ import scala.concurrent.Future
   */
 @Singleton
 class GreeterRouter @Inject()(cc: ControllerComponents, impl: GreeterServiceImpl)(implicit mat: Materializer)
-  extends Router {
+  extends SimpleRouter {
 
   val handler = new AkkaHttpHandler {
     val h = GreeterServiceHandler(impl)
@@ -27,9 +27,19 @@ class GreeterRouter @Inject()(cc: ControllerComponents, impl: GreeterServiceImpl
   }
 
   // could look at GreeterService.name, but isn't this already covered in the route file?
-  override def routes: Routes = { case _ ⇒ handler }
+  override def routes: Routes = {
 
-  override def documentation: Seq[(String, String, String)] = Seq.empty
+    case reqHeader ⇒
 
-  override def withPrefix(prefix: String): Router = this
+      println(s"""
+                  | in service 1
+                  | host: ${reqHeader.host}
+                  | path: ${reqHeader.path}
+                  | version: ${reqHeader.version}
+                  | -----------------------------------------
+                """.stripMargin)
+      handler
+
+  }
+
 }

--- a/app/controllers/GreeterRouter2.scala
+++ b/app/controllers/GreeterRouter2.scala
@@ -1,0 +1,37 @@
+package controllers
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.Materializer
+import io.grpc.examples.helloworld2.{GreeterService, GreeterServiceHandler}
+import javax.inject.Inject
+import play.api.mvc.ControllerComponents
+import play.api.mvc.akkahttp.AkkaHttpHandler
+import play.api.routing.{Router, SimpleRouter}
+import play.api.routing.Router.Routes
+
+import scala.concurrent.Future
+
+class GreeterRouter2  @Inject()(cc: ControllerComponents, impl: GreeterService2Impl)(implicit mat: Materializer)
+  extends SimpleRouter {
+
+  val handler = new AkkaHttpHandler {
+    val h = GreeterServiceHandler(impl)
+    override def apply(request: HttpRequest): Future[HttpResponse] = h(request)
+  }
+
+  // could look at GreeterService.name, but isn't this already covered in the route file?
+  override def routes: Routes = {
+
+    case reqHeader ⇒
+      println(s"""
+                 | in service 2
+                 | host: ${reqHeader.host}
+                 | path: ${reqHeader.path}
+                 | version: ${reqHeader.version}
+                 | -----------------------------------------
+                """.stripMargin)
+      handler
+
+  }
+
+}

--- a/app/controllers/GreeterService2Impl.scala
+++ b/app/controllers/GreeterService2Impl.scala
@@ -3,17 +3,17 @@ package controllers
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import io.grpc.examples.helloworld.{GreeterService, HelloReply, HelloRequest}
+import io.grpc.examples.helloworld2.{HelloReply, HelloRequest}
+import io.grpc.examples.helloworld2.{GreeterService, HelloReply, HelloRequest}
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.Future
 
-/** Would be written by the user, with support for dependency injection etc */
 @Singleton
-class GreeterServiceImpl @Inject()(implicit mat: Materializer) extends GreeterService {
+class GreeterService2Impl @Inject()(implicit mat: Materializer)  extends GreeterService {
   println(s"Got injected $mat")
 
-  override def sayHello(in: HelloRequest): Future[HelloReply] = Future.successful(HelloReply(s"Hello, ${in.name} (service1)!"))
+  override def sayHello(in: HelloRequest): Future[HelloReply] = Future.successful(HelloReply(s"Hello, ${in.name} (service2)!"))
 
   override def itKeepsTalking(in: Source[HelloRequest, NotUsed]): Future[HelloReply] = ???
 

--- a/app/protobuf/helloworld2.proto
+++ b/app/protobuf/helloworld2.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld2";
+option java_outer_classname = "HelloWorldProto2";
+
+package helloworld2;
+
+//// The greeting service definition.
+service GreeterService {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsTalking (stream HelloRequest) returns (HelloReply) {}
+
+    rpc ItKeepsReplying (HelloRequest) returns (stream HelloReply) {}
+
+    rpc StreamHellos (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.HomeController.index
+# GET     /                           controllers.HomeController.index
 # An example controller showing how to use dependency injection
 GET     /count                      controllers.CountController.count
 # An example controller showing how to write asynchronous code
@@ -12,4 +12,5 @@ GET     /message                    controllers.AsyncController.message
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(file)
 
+->     /helloworld2.GreeterService   controllers.GreeterRouter2
 ->     /helloworld.GreeterService   controllers.GreeterRouter


### PR DESCRIPTION
This PR is only to illustrate a bug I detected in the way were are build the Play Router.
This should be integrated on the code gen here:
https://github.com/akka/akka-grpc/pull/251

In this PR, we have two, almost identical, `GreeterService`. The routes file is defined as such:

```
->     /helloworld2.GreeterService   controllers.GreeterRouter2
->     /helloworld.GreeterService   controllers.GreeterRouter
```

**Without** the fix and after calling it with:

```
grpcc -a localhost:9443 -p app/protobuf/helloworld.proto --eval 'client.sayHello({ name: "John" }, printReply)' --root_cert ./playgeneratedtrusted.pem
```

We will see the `println`:
```
 in service 2
 host: localhost:9443
 path: /helloworld.GreeterService/SayHello
 version: HTTP/2.0
 -----------------------------------------
```
and the call fails on the client side.


On the other hand, the call below will succeed because it's target to helloworld2 service and is handled correctly by it.
```
grpcc -a localhost:9443 -p app/protobuf/helloworld2.proto --eval 'client.sayHello({ name: "John" }, printReply)' --root_cert ./playgeneratedtrusted.pem
```  

The reason for that is that generated final `Routes` will pass the path declared in the `routes` file to the `withPrefix` method in the `Router`, which is implemented as `override def withPrefix(prefix: String): Router = this`.

The consequence is that we are making a catch-all route that will match whatever path. When we add two gRPC routes we will see that the first will catch everything. And because the Router PF is also using a catch-all ( { `case _ => handler }), we simply pass through and hit the gRPC service.

The simple fix is to extend `SimpleRouter` instead of `Router`, the `withPrefix` in `SimpleRouter` does what is needed. 

