### PR TITLE
Correctly handle only relevant requests in the router

### DIFF
--- a/app/controllers/GreeterRouter.scala
+++ b/app/controllers/GreeterRouter.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.Materializer
 import io.grpc.examples.helloworld.{GreeterService, GreeterServiceHandler}
 import javax.inject._
-import play.api.mvc._
 import play.api.mvc.akkahttp.AkkaHttpHandler
 import play.api.routing.Router
 import play.api.routing.Router.Routes
@@ -18,8 +17,10 @@ import scala.concurrent.Future
   * Is there a nice place where we can ask the user to 'binder.bind(classOf[GreeterService]).to(classOf[GreeterServiceImpl])'?
   */
 @Singleton
-class GreeterRouter @Inject()(cc: ControllerComponents, impl: GreeterServiceImpl)(implicit mat: Materializer)
+class GreeterRouter @Inject()(impl: GreeterServiceImpl)(implicit mat: Materializer)
   extends Router {
+
+  protected val prefix: String = GreeterService.name
 
   val handler = new AkkaHttpHandler {
     val h = GreeterServiceHandler(impl)
@@ -27,9 +28,19 @@ class GreeterRouter @Inject()(cc: ControllerComponents, impl: GreeterServiceImpl
   }
 
   // could look at GreeterService.name, but isn't this already covered in the route file?
-  override def routes: Routes = { case _ ⇒ handler }
+  override def routes: Routes = {
+    case rh if rh.path.startsWith(prefix) ⇒ handler
+  }
 
   override def documentation: Seq[(String, String, String)] = Seq.empty
 
-  override def withPrefix(prefix: String): Router = this
+  override def withPrefix(additionalPrefix: String): Router = {
+      val newPrefix =
+        if (prefix == GreeterService.name) additionalPrefix
+        else Router.prefixPath(additionalPrefix + prefix)
+
+      new GreeterRouter(impl) {
+        override val prefix = newPrefix
+      }
+    }
 }


### PR DESCRIPTION
Based on https://github.com/akka/akka-grpc/pull/251,
https://github.com/raboof/play-scala-grpc-server/pull/3 and a call
with @renatocaval